### PR TITLE
Updates !create_cohort

### DIFF
--- a/rust-bot/src/main.rs
+++ b/rust-bot/src/main.rs
@@ -47,9 +47,13 @@ fn create_cohort(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandRes
     msg.channel_id
         .say(&ctx.http, "Spinning up Adventure Club...")?;
 
+    // Check for adventure club category id
+    // You can quickly grab this from "Copy Id"
+    // on the category
+    let category_id = env::var("A_CLUB_CAT_ID").expect("Double check that you set the adventure club category id properly").parse::<u64>()?;
     let (cohort_name, channel_name) = gen_names(args.single::<String>().unwrap());
     let role = create_role(ctx, msg, &cohort_name);
-    let channel = create_channel(ctx, msg, &channel_name, role);
+    let channel = create_channel(ctx, msg, &channel_name, category_id, role);
 
     match channel {
         Ok(channel) => {
@@ -96,6 +100,7 @@ fn create_channel(
     ctx: &mut Context,
     msg: &Message,
     channel_name: &str,
+    category_id: u64, 
     role: Role,
 ) -> Result<GuildChannel, Error> {
     let role_id = role.id;
@@ -105,6 +110,7 @@ fn create_channel(
     let guild = msg.guild(&ctx.cache).unwrap();
     let new_channel = guild.read().create_channel(&ctx.http, |c| {
         c.name(channel_name)
+            .category(category_id)
             .kind(ChannelType::Text)
             .permissions(permission_set)
     });

--- a/rust-bot/src/main.rs
+++ b/rust-bot/src/main.rs
@@ -180,13 +180,13 @@ fn main() {
 #[check]
 #[name = "Mod"]
 fn mod_check(ctx: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> CheckResult {
+    // Party Corgi - Mod Role Id = 639531892437286959
+    let mod_role_id: RoleId = 639531892437286959.into();
     if let Some(member) = msg.member(&ctx.cache) {
-        if let Ok(permissions) = member.permissions(&ctx.cache) {
-            return permissions.administrator().into();
-        }
+        return member.roles.contains(&mod_role_id).into();
     }
 
-    false.into()
+    return false.into();
 }
 #[instrument]
 // Generate cohort and channel names


### PR DESCRIPTION
This PR does quite a bit for us and wasn't quite sure how to articulate it all in the title so I will write it all here:

- Updates the mod check to check for our mod RoleId
- Add cohort channel to a category (**ADD THE CATEGORY ID TO THE ENV**)
- Adds color to the adventure club role (`#ff7f8a` as u64 `16744330`)
- Implements a response message that builds out the channel and mentions the role

Here's what it all looks like together:
![image](https://user-images.githubusercontent.com/8431042/90582298-64782f80-e19b-11ea-9104-00c6b342da95.png)
