### PR TITLE
rust: fixes honeycomb tracing

### DIFF
--- a/rust-bot/src/main.rs
+++ b/rust-bot/src/main.rs
@@ -164,6 +164,8 @@ struct Handler;
 impl EventHandler for Handler {
     #[instrument]
     fn ready(&self, _: Context, _ready_info: serenity::model::gateway::Ready) {
+        //generate a trace for the ready command so the ready info can be sent to Honeycomb. 
+       let _result = register_dist_tracing_root(TraceId::generate(), None);
         info!(bot_is_ready = ?std::time::SystemTime::now());
     }
 }


### PR DESCRIPTION
This fixes the issues that were preventing anything from getting posted to honeycomb. Essentially, we need to call the `register_dist_tracing_root` function in context of a span. Then, when that span ends, it will send data to honeycomb. Since there's no way to do this for the lifetime of each message that comes in (at least right now), I'm using the message_id as a trace_id for honeycomb. That way when we implement the `before` and `after` commands, we can get a single trace for each message. We may run into issues with edits, assuming the message id stays the same before & after an edit. But, we can do something different for those requests later on. 

Thinking long-term we either override the StandardFramework (we really just need to override the dispatch command afaict), or create our own version of the `#[instrument]` macro that does the dist-tracing stuff for us (and maybe registers an event so we always send all of our args to honeycomb??). 

I also went through and added some more events to the current commands so we can get more than just ping! & pong! in honeycomb. 

