### PR TITLE
adds a line to copy yee-claw.png to Dockerfile

### DIFF
--- a/rust-bot/Dockerfile
+++ b/rust-bot/Dockerfile
@@ -6,5 +6,6 @@ RUN cargo install --path .
 FROM debian:buster
 LABEL corgo.language="rust"
 COPY --from=0 /usr/local/cargo/bin/corgo-rust /opt/corgo-rust
+COPY ./yee-claw.png /
 RUN apt-get update && apt-get install -y libssl-dev && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT /opt/corgo-rust


### PR DESCRIPTION
Fixes the yee-claw command by copying over yee-claw.png to the runtime dockerfile. We could probably abstract this to any .png in the future, but this seems good enough for now. 