### PR TITLE
modularize stuff from stream

### DIFF
--- a/rust-bot/src/commands/mod.rs
+++ b/rust-bot/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod mod_group;

--- a/rust-bot/src/commands/mod_group.rs
+++ b/rust-bot/src/commands/mod_group.rs
@@ -1,0 +1,170 @@
+use std::env;
+
+use tracing::{error, info, instrument};
+
+use serenity::{
+    framework::standard::macros::{check, command, group},
+    framework::standard::{Args, CheckResult, CommandOptions, CommandResult},
+    model::{
+        channel::{ChannelType, GuildChannel, PermissionOverwrite, PermissionOverwriteType},
+        guild::Role,
+        id::RoleId,
+        permissions::Permissions,
+        prelude::Message,
+    },
+    prelude::*,
+    utils::MessageBuilder,
+    Error,
+};
+
+#[group]
+#[checks(Mod)]
+#[commands(create_cohort)]
+struct Mod;
+
+// This command provisions out a channel with permissions
+// to read/write for users with the corresponding role. It
+// will also make the channel read-only for other users.
+#[instrument(skip(ctx))]
+#[command]
+fn create_cohort(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
+    msg.channel_id
+        .say(&ctx.http, "Spinning up Adventure Club...")?;
+
+    // Check for adventure club category id
+    // You can quickly grab this from "Copy Id"
+    // on the category
+    let category_id = env::var("A_CLUB_CAT_ID")
+        .expect("Double check that you set the adventure club category id properly")
+        .parse::<u64>()?;
+    let (cohort_name, channel_name) = gen_names(args.single::<String>().unwrap());
+    info!(
+        ?cohort_name,
+        ?channel_name,
+        channel = tracing::field::Empty,
+        role = tracing::field::Empty,
+        err = tracing::field::Empty
+    );
+    let role = create_role(ctx, msg, &cohort_name);
+    let channel = create_channel(ctx, msg, &channel_name, category_id, &role);
+    info!(?role, ?channel);
+    match channel {
+        Ok(channel) => {
+            let reply_msg = MessageBuilder::new()
+                .push("Successfully created club channel: ")
+                .channel(channel)
+                .push("! Feel free to add users with the ")
+                .role(role)
+                .push(" role.")
+                .build();
+            info!(?reply_msg);
+            msg.reply(&ctx.http, reply_msg).unwrap();
+        }
+        Err(err) => {
+            msg.reply(&ctx.http, "Failed to create cohort").unwrap();
+            info!(?err)
+        }
+    };
+
+    Ok(())
+}
+#[instrument(skip(ctx))]
+fn create_role(ctx: &mut Context, msg: &Message, role_name: &str) -> Role {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let role = match guild.read().role_by_name(role_name) {
+        Some(role) => {
+            let content = format!("{} Role already exists!", role.name);
+            info!(role_exists = true);
+            if let Err(error) = msg.channel_id.say(&ctx.http, content) {
+                error!(err = ?error);
+                println!("{:?}", error);
+            };
+            info!(role_exists = true, ?role);
+            role.clone()
+        }
+        None => {
+            info!(role_exists = false);
+            guild
+                .read()
+                .create_role(&ctx, |r| r.name(role_name).colour(16744330))
+                .unwrap()
+        }
+    };
+    return role;
+}
+
+// Permissions for chatting happen here
+#[instrument(skip(ctx))]
+fn create_channel(
+    ctx: &mut Context,
+    msg: &Message,
+    channel_name: &str,
+    category_id: u64,
+    role: &Role,
+) -> Result<GuildChannel, Error> {
+    let role_id = role.id;
+    let everyone_id = get_everyone_role(ctx, msg).unwrap().id;
+    let permission_set = mute_users_without_role_permset(role_id, everyone_id);
+
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let new_channel = guild.read().create_channel(&ctx.http, |c| {
+        c.name(channel_name)
+            .category(category_id)
+            .kind(ChannelType::Text)
+            .permissions(permission_set)
+    });
+    info!(?new_channel);
+    new_channel
+}
+
+#[instrument(skip(ctx))]
+#[check]
+#[name = "Mod"]
+fn mod_check(ctx: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> CheckResult {
+    // Party Corgi - Mod Role Id = 639531892437286959
+    let mod_role_id: RoleId = 639531892437286959.into();
+    if let Some(member) = msg.member(&ctx.cache) {
+        return member.roles.contains(&mod_role_id).into();
+    }
+
+    return false.into();
+}
+#[instrument]
+// Generate cohort and channel names
+fn gen_names(input_str: String) -> (String, String) {
+    let cohort_name = format!("adventure-club: {}", input_str);
+    let channel_name = format!("{}", input_str);
+
+    (cohort_name, channel_name)
+}
+#[instrument]
+fn mute_users_without_role_permset(
+    role_id: RoleId,
+    everyone_role_id: RoleId,
+) -> Vec<PermissionOverwrite> {
+    let mut remove_messaging = Permissions::empty();
+    remove_messaging.insert(Permissions::SEND_MESSAGES);
+    remove_messaging.insert(Permissions::SEND_TTS_MESSAGES);
+    vec![
+        PermissionOverwrite {
+            allow: Permissions::SEND_MESSAGES,
+            deny: Permissions::empty(),
+            kind: PermissionOverwriteType::Role(role_id),
+        },
+        PermissionOverwrite {
+            allow: Permissions::empty(),
+            deny: remove_messaging,
+            kind: PermissionOverwriteType::Role(everyone_role_id),
+        },
+    ]
+}
+#[instrument(skip(ctx))]
+fn get_everyone_role(ctx: &mut Context, msg: &Message) -> Option<Role> {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    for (_, role) in guild.read().roles.iter() {
+        if role.name == "@everyone" {
+            return Some(role.clone());
+        }
+    }
+    return None;
+}

--- a/rust-bot/src/main.rs
+++ b/rust-bot/src/main.rs
@@ -1,46 +1,30 @@
-use std::{
-    env,
-    path::Path,
-    str::FromStr
-};
+use std::{env, path::Path, str::FromStr};
 
 use libhoney;
 use std::collections::HashSet;
 use tracing::{error, info, instrument};
-use tracing_honeycomb:: {
-    register_dist_tracing_root, TraceId
-};
+use tracing_honeycomb::{register_dist_tracing_root, TraceId};
 use tracing_subscriber::layer::SubscriberExt;
 
 use serenity::{
-    framework::standard::macros::{check, command, group},
+    framework::standard::macros::{command, group},
     framework::standard::{
-        help_commands, macros::help, Args, CheckResult, CommandGroup, CommandOptions,
-        CommandResult, HelpOptions, StandardFramework,
+        help_commands, macros::help, Args, CommandGroup, CommandResult, HelpOptions,
+        StandardFramework,
     },
     http::AttachmentType,
-    model::{
-        channel::{ChannelType, GuildChannel, PermissionOverwrite, PermissionOverwriteType},
-        guild::Role,
-        id::RoleId,
-        permissions::Permissions,
-        prelude::{Message, MessageActivityKind, UserId},
-    },
+    model::prelude::{Message, MessageActivityKind, UserId},
     prelude::*,
-    utils::MessageBuilder,
-    Error,
 };
+
+mod commands;
+use commands::mod_group::MOD_GROUP;
 
 const CHANNEL__LISTENING_PARTY: u64 = 742445700998103132;
 
 #[group]
 #[commands(yee_claw, ping, pin)]
 struct General;
-
-#[group]
-#[checks(Mod)]
-#[commands(create_cohort)]
-struct Mod;
 
 // The framework provides two built-in help commands for you to use.
 // But you can also make your own customized help command that forwards
@@ -123,10 +107,10 @@ fn pin(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
 #[command]
 #[aliases("yee-claw")]
 fn yee_claw(ctx: &mut Context, msg: &Message) -> CommandResult {
-let _result = register_dist_tracing_root(generate_trace_id_from_message(msg), None);
+    let _result = register_dist_tracing_root(generate_trace_id_from_message(msg), None);
     if let Err(why) = msg.channel_id.send_message(&ctx.http, |m| {
         m.content("Yeee-claw!")
-        .add_file(AttachmentType::Path(Path::new("./yee-claw.png")));
+            .add_file(AttachmentType::Path(Path::new("./yee-claw.png")));
         m
     }) {
         println!("Error sending message {}", why);
@@ -134,102 +118,14 @@ let _result = register_dist_tracing_root(generate_trace_id_from_message(msg), No
     Ok(())
 }
 
-// This command provisions out a channel with permissions
-// to read/write for users with the corresponding role. It
-// will also make the channel read-only for other users.
-#[instrument(skip(ctx))]
-#[command]
-fn create_cohort(ctx: &mut Context, msg: &Message, mut args: Args) -> CommandResult {
-    msg.channel_id
-        .say(&ctx.http, "Spinning up Adventure Club...")?;
-
-    // Check for adventure club category id
-    // You can quickly grab this from "Copy Id"
-    // on the category
-    let category_id = env::var("A_CLUB_CAT_ID")
-        .expect("Double check that you set the adventure club category id properly")
-        .parse::<u64>()?;
-    let (cohort_name, channel_name) = gen_names(args.single::<String>().unwrap());
-    info!(?cohort_name, ?channel_name, channel = tracing::field::Empty, role = tracing::field::Empty, err = tracing::field::Empty);
-    let role = create_role(ctx, msg, &cohort_name);
-    let channel = create_channel(ctx, msg, &channel_name, category_id, &role);
-    info!(?role, ?channel);
-    match channel {
-        Ok(channel) => {
-            let reply_msg = MessageBuilder::new()
-                .push("Successfully created club channel: ")
-                .channel(channel)
-                .push("! Feel free to add users with the ")
-                .role(role)
-                .push(" role.")
-                .build();
-            info!(?reply_msg);
-            msg.reply(&ctx.http, reply_msg).unwrap();
-        }
-        Err(err) => {
-            msg.reply(&ctx.http, "Failed to create cohort").unwrap();
-            info!(?err)
-        }
-    };
-
-    Ok(())
-}
-#[instrument(skip(ctx))]
-fn create_role(ctx: &mut Context, msg: &Message, role_name: &str) -> Role {
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let role = match guild.read().role_by_name(role_name) {
-        Some(role) => {
-            let content = format!("{} Role already exists!", role.name);
-            info!(role_exists = true);
-            if let Err(error) = msg.channel_id.say(&ctx.http, content) {
-                error!(err = ?error);
-                println!("{:?}", error);
-            };
-            info!(role_exists = true, ?role);
-            role.clone()
-        }
-        None => {
-            info!(role_exists = false);
-            guild
-                .read()
-                .create_role(&ctx, |r| r.name(role_name).colour(16744330))
-                .unwrap()
-        }
-    };
-    return role;
-}
-
-// Permissions for chatting happen here
-#[instrument(skip(ctx))]
-fn create_channel(
-    ctx: &mut Context,
-    msg: &Message,
-    channel_name: &str,
-    category_id: u64,
-    role: &Role,
-) -> Result<GuildChannel, Error> {
-    let role_id = role.id;
-    let everyone_id = get_everyone_role(ctx, msg).unwrap().id;
-    let permission_set = mute_users_without_role_permset(role_id, everyone_id);
-
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let new_channel = guild.read().create_channel(&ctx.http, |c| {
-        c.name(channel_name)
-            .category(category_id)
-            .kind(ChannelType::Text)
-            .permissions(permission_set)
-    });
-    info!(?new_channel);
-    new_channel
-}
 #[derive(Debug)]
 struct Handler;
 
 impl EventHandler for Handler {
     #[instrument]
     fn ready(&self, _: Context, _ready_info: serenity::model::gateway::Ready) {
-        //generate a trace for the ready command so the ready info can be sent to Honeycomb. 
-       let _result = register_dist_tracing_root(TraceId::generate(), None);
+        //generate a trace for the ready command so the ready info can be sent to Honeycomb.
+        let _result = register_dist_tracing_root(TraceId::generate(), None);
         info!(bot_is_ready = ?std::time::SystemTime::now());
     }
     #[instrument(skip(_ctx, _new_message))]
@@ -300,66 +196,16 @@ fn main() {
         println!("Client error: {:?}", why);
     }
 }
-#[instrument(skip(ctx))]
-#[check]
-#[name = "Mod"]
-fn mod_check(ctx: &mut Context, msg: &Message, _: &mut Args, _: &CommandOptions) -> CheckResult {
-    // Party Corgi - Mod Role Id = 639531892437286959
-    let mod_role_id: RoleId = 639531892437286959.into();
-    if let Some(member) = msg.member(&ctx.cache) {
-        return member.roles.contains(&mod_role_id).into();
-    }
 
-    return false.into();
-}
-#[instrument]
-// Generate cohort and channel names
-fn gen_names(input_str: String) -> (String, String) {
-    let cohort_name = format!("adventure-club: {}", input_str);
-    let channel_name = format!("{}", input_str);
-
-    (cohort_name, channel_name)
-}
-#[instrument]
-fn mute_users_without_role_permset(
-    role_id: RoleId,
-    everyone_role_id: RoleId,
-) -> Vec<PermissionOverwrite> {
-    let mut remove_messaging = Permissions::empty();
-    remove_messaging.insert(Permissions::SEND_MESSAGES);
-    remove_messaging.insert(Permissions::SEND_TTS_MESSAGES);
-    vec![
-        PermissionOverwrite {
-            allow: Permissions::SEND_MESSAGES,
-            deny: Permissions::empty(),
-            kind: PermissionOverwriteType::Role(role_id),
-        },
-        PermissionOverwrite {
-            allow: Permissions::empty(),
-            deny: remove_messaging,
-            kind: PermissionOverwriteType::Role(everyone_role_id),
-        },
-    ]
-}
-#[instrument(skip(ctx))]
-fn get_everyone_role(ctx: &mut Context, msg: &Message) -> Option<Role> {
-    let guild = msg.guild(&ctx.cache).unwrap();
-    for (_, role) in guild.read().roles.iter() {
-        if role.name == "@everyone" {
-            return Some(role.clone());
-        }
-    }
-    return None;
-}
 // Generates a TraceId from the message.id. If the cast fails, create a random TraceId.
 // We do this so that we can have a single trace that spans the length of the message.
 // This way we can use the "before" & "after" fns in a single trace.
-//Note that we assume that message ids are permanently unique to do this. 
+//Note that we assume that message ids are permanently unique to do this.
 fn generate_trace_id_from_message(msg: &Message) -> TraceId {
     match TraceId::from_str(&msg.id.to_string()) {
         Ok(trace_id) => trace_id,
         Err(err) => {
-            // if casting errors, generate a fresh id. 
+            // if casting errors, generate a fresh id.
             error!(message_id = %msg.id, ?err,  "error_converting_message_id_to_trace" );
             TraceId::generate()
         }


### PR DESCRIPTION
Start separating commands into modules.

Rust modules are defined *from the parent* so we define the module `commands` in `main.rs` and the *public* module `mod_group` in `commands`. In `main.rs` we also say that we're going to `use` the `MOD_GROUP` struct which is generated at build-time by the Serenity macro.

```rust
use commands::mod_group::MOD_GROUP;
```

The module tree looks like this:

```
➜ tree .
.
└── commands
    └── mod_group
```
