### PR TITLE
Add custom welcome messages for when users join the server

### DIFF
--- a/rust-bot/Cargo.lock
+++ b/rust-bot/Cargo.lock
@@ -205,6 +205,9 @@ name = "corgo-rust"
 version = "0.1.0"
 dependencies = [
  "libhoney-rust 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serenity 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-honeycomb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust-bot/Cargo.toml
+++ b/rust-bot/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "=0.7.2"
+serde = "=1.0.101"
+serde_json = "1.0"
 serenity = "0.8"
 tracing-honeycomb = "0.1.0"
 libhoney-rust = "^0.1.3"

--- a/rust-bot/src/main.rs
+++ b/rust-bot/src/main.rs
@@ -14,8 +14,7 @@ use serenity::{
     },
     http::AttachmentType,
     model::prelude::{ChannelId, GuildId, Member, Message, MessageActivityKind, UserId},
-    prelude::*,
-    utils::MessageBuilder,
+    prelude::*
 };
 
 mod commands;
@@ -149,18 +148,10 @@ impl EventHandler for Handler {
 
     #[instrument(skip(ctx, _guild_id))]
     fn guild_member_addition(&self, ctx: Context, _guild_id: GuildId, new_member: Member) {
-        let rand_msg = welcome_message::get_welcome_message();
         let channel = ChannelId(CHANNEL__GENERAL);
 
         if let Err(err_msg) = channel.send_message(&ctx.http, |msg| {
-            let welcome_message = MessageBuilder::new()
-                .push(&rand_msg.before_mention)
-                .mention(&new_member)
-                .push(&rand_msg.after_mention)
-                .build();
-
-            msg.content(welcome_message);
-
+            msg.content(welcome_message::get_welcome_message(&new_member));
             msg
         }) {
             error!(err = ?err_msg);

--- a/rust-bot/src/welcome_message.rs
+++ b/rust-bot/src/welcome_message.rs
@@ -1,0 +1,37 @@
+use rand::seq::SliceRandom;
+use serde::Deserialize;
+use std::fs::File;
+use std::io::BufReader;
+use tracing::error;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct WelcomeMessage {
+    pub before_mention: String,
+    pub after_mention: String,
+}
+
+fn read_welcome_messages_from_file() -> Vec<WelcomeMessage> {
+    let file = File::open("welcome_messages.json")
+        .expect("There was no welcome_messages.json found");
+    let reader = BufReader::new(file);
+
+    let welcome_messages = serde_json::from_reader(reader)
+        .expect("welcome_messages.json wasn't able to be parsed properly");
+
+    welcome_messages
+}
+
+pub fn get_welcome_message() -> WelcomeMessage {
+    let welcome_messages = read_welcome_messages_from_file();
+
+    match welcome_messages.choose(&mut rand::thread_rng()) {
+        Some(welcome_message) => return welcome_message.clone(),
+        None => {
+          error!(err = "No welcome message was found from the file");
+          return WelcomeMessage {
+            before_mention: String::from("Welcome to the server, "),
+            after_mention: String::from(".")
+          }
+        },
+    }
+}

--- a/rust-bot/src/welcome_message.rs
+++ b/rust-bot/src/welcome_message.rs
@@ -3,6 +3,10 @@ use serde::Deserialize;
 use std::fs::File;
 use std::io::BufReader;
 use tracing::error;
+use serenity::{
+  model::misc::Mentionable,
+  utils::MessageBuilder
+};
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct WelcomeMessage {
@@ -21,17 +25,25 @@ fn read_welcome_messages_from_file() -> Vec<WelcomeMessage> {
     welcome_messages
 }
 
-pub fn get_welcome_message() -> WelcomeMessage {
+pub fn get_welcome_message(new_member: &impl Mentionable) -> String {
     let welcome_messages = read_welcome_messages_from_file();
 
-    match welcome_messages.choose(&mut rand::thread_rng()) {
-        Some(welcome_message) => return welcome_message.clone(),
+    let rand_msg = match welcome_messages.choose(&mut rand::thread_rng()) {
+        Some(welcome_message) => welcome_message.clone(),
         None => {
           error!(err = "No welcome message was found from the file");
-          return WelcomeMessage {
+          WelcomeMessage {
             before_mention: String::from("Welcome to the server, "),
             after_mention: String::from(".")
           }
         },
-    }
+    };
+
+    let welcome_message = MessageBuilder::new()
+    .push(&rand_msg.before_mention)
+    .mention(new_member)
+    .push(&rand_msg.after_mention)
+    .build();
+
+    welcome_message
 }

--- a/rust-bot/welcome_messages.json
+++ b/rust-bot/welcome_messages.json
@@ -2,5 +2,9 @@
   {
     "before_mention": "Welcome our new party corgi, ",
     "after_mention": "!"
+  },
+  {
+    "before_mention": "Hey, ",
+    "after_mention": "! Welcome to the party!"
   }
 ]

--- a/rust-bot/welcome_messages.json
+++ b/rust-bot/welcome_messages.json
@@ -1,0 +1,6 @@
+[
+  {
+    "before_mention": "Welcome our new party corgi, ",
+    "after_mention": "!"
+  }
+]

--- a/rust-bot/welcome_messages_.json
+++ b/rust-bot/welcome_messages_.json
@@ -1,6 +1,0 @@
-[
-  {
-    "before_mention": "Everyone, welcome our new party corgi, ",
-    "after_mention": "!"
-  }
-]

--- a/rust-bot/welcome_messages_.json
+++ b/rust-bot/welcome_messages_.json
@@ -1,0 +1,6 @@
+[
+  {
+    "before_mention": "Everyone, welcome our new party corgi, ",
+    "after_mention": "!"
+  }
+]


### PR DESCRIPTION
We can now have custom welcome messages! The bot would send the message and it would continue to @mention them in whatever channel we want (designated by `CHANNEL__GENERAL` for now).

This photo is an example of what it would look like (though I've taken that particular example out.
![image](https://user-images.githubusercontent.com/8431042/95283011-b434b800-0828-11eb-87bb-1f3ad6646560.png)

We had to add some `serde` and `rand` crates so we can have a random selection from a file. This was also to make it easier for folks to contribute to the list. I think the specific language of `before_mention` and `after_mention` is helpful to keep a strict format of what we the message to look like. But I'm open to suggestions.